### PR TITLE
fix(layout): adds the mobile menu on iPad Mini resolution too

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -57,7 +57,7 @@ const Layout = ({ children }: LayoutProps) => {
       </div>
 
       <Sidebar open={isSidebarOpen} setClosed={() => setSidebarOpen(false)} />
-      <div className="sm:hidden">
+      <div className="hidden sm:block">
         <MobileMenu />
       </div>
 
@@ -74,7 +74,7 @@ const Layout = ({ children }: LayoutProps) => {
         >
           <div className="flex flex-1 items-center justify-between px-4 md:pr-4 md:pl-4">
             <button
-              className={`mr-2 hidden text-white sm:block ${
+              className={`mr-2 hidden text-white sm:hidden ${
                 isScrolled ? 'opacity-90' : 'opacity-70'
               } transition duration-300 focus:outline-none lg:hidden`}
               aria-label="Open sidebar"


### PR DESCRIPTION
#### Description
Tweak layout to show mobile nav with new back button on iPad mini too

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
